### PR TITLE
Cache to registry image instead of gha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,8 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           target: final
-          cache-from: type=gha
-          cache-to: ${{ github.event_name == 'release' && 'type=gha' || '' }}
+          cache-from: type=registry,ref=ghcr.io/esphome/docker-base:cache
+          cache-to: ${{ github.event_name == 'release' && 'type=registry,ref=ghcr.io/esphome/docker-base:cache' || '' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/esphome/docker-base:${{ steps.get_tag.outputs.version }}


### PR DESCRIPTION
This is because the gha cache is created in the scope of the tag itself and future tags cannot access the cache.