### PR TITLE
Dependency bumps

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,7 +8,7 @@ RUN \
   && apk add --no-cache \
       bash=5.2.26-r0 \
       git=2.45.2-r0 \
-      curl=8.10.0-r0 \
+      curl=8.10.1-r0 \
       openssh-client=9.7_p1-r4 \
       cairo=1.18.0-r0 \
       libmagic=5.45-r1 \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
       iputils-ping=3:20221126-1 \
-      git=1:2.39.2-1.1 \
+      git=1:2.39.5-0+deb12u1 \
       curl=7.88.1-10+deb12u7 \
       openssh-client=1:9.2p1-2+deb12u3 \
       libcairo2=1.16.0-7 \


### PR DESCRIPTION
These are required for the images to build again since I forgot to release a version (making the cache available)