### PR TITLE
Reduce need for privileged mode a bit more

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -20,6 +20,8 @@ RUN \
       /var/lib/apt/lists/* \
       /usr/src/*
 
+RUN usermod -U root -a -G staff
+
 ENV UV_SYSTEM_PYTHON=true
 ENV PIP_ROOT_USER_ACTION=ignore
 


### PR DESCRIPTION
Currently the general advise is to just use privileged mode with docker/compose. From a security point of view this is obviously undesirable.

One reason why privileged mode is needed, is because some packages [0] incorrectly set permissions on their (`-rwxr-x--- 501:staff package.json`) file. One would rightfully argue, that this doesn't matter, because docker runs as root and thus all permissions are granted anyway. However when working with volumes, this is no longer true, the docker user is mapped to some random UID and within our container we now get a permission denied error, because our remapped root user no longer has access.

While we obviously should aim to fix this error upstream wherever possible, this could take years. Meanwhile lets put the root user into the `staff` group, which seems to be the permissions set by these misbehaving packages. Obviously this will break again once upstream or debian changes the mapping/permission at a later time.

[0]: https://community.platformio.org/t/incorrect-permissions-for-several-packages-on-package-json/41733