### PR TITLE
Bump all dependencies

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine3.20 AS base
+FROM python:3.13-alpine3.22 AS base
 
 ENV \
     UV_EXTRA_INDEX_URL=https://wheels.home-assistant.io/musllinux-index/
@@ -6,13 +6,13 @@ ENV \
 RUN \
   set -x \
   && apk add --no-cache \
-      bash=5.2.26-r0 \
-      git=2.45.3-r0 \
-      curl=8.12.1-r0 \
-      openssh-client=9.7_p1-r5 \
-      cairo=1.18.0-r0 \
-      libmagic=5.45-r1 \
-      patch=2.7.6-r10
+      bash=5.2.37-r0 \
+      git=2.49.1-r0 \
+      curl=8.14.1-r2 \
+      openssh-client-default=10.0_p1-r10 \
+      cairo=1.18.4-r0 \
+      libmagic=5.46-r2 \
+      patch=2.8-r0
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -25,14 +25,14 @@ FROM base AS ha-addon
 RUN \
     set -x \
     && apk add --no-cache \
-        nginx=1.26.3-r0 \
-        jq=1.7.1-r0 \
-        xz=5.6.2-r1
+        nginx=1.28.3-r0 \
+        jq=1.8.1-r0 \
+        xz=5.8.1-r0
 
 ARG \
-    BASHIO_VERSION=0.16.3 \
+    BASHIO_VERSION=0.17.5 \
     TEMPIO_VERSION=2024.11.2 \
-    S6_OVERLAY_VERSION=3.2.0.2
+    S6_OVERLAY_VERSION=3.2.2.0
 
 WORKDIR /usr/src
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm AS base
+FROM python:3.13-slim-trixie AS base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -6,13 +6,13 @@ RUN \
   set -x \
   && apt update \
   && apt install -y --no-install-recommends \
-      iputils-ping=3:20221126-1+deb12u1 \
-      git=1:2.39.5-0+deb12u2 \
-      curl=7.88.1-10+deb12u12 \
-      openssh-client=1:9.2p1-2+deb12u5 \
-      libcairo2=1.16.0-7 \
-      libmagic1=1:5.44-3 \
-      patch=2.7.6-7 \
+      iputils-ping=3:20240905-3 \
+      git=1:2.47.3-0+deb13u1 \
+      curl=8.14.1-2+deb13u2 \
+      openssh-client=1:10.0p1-7+deb13u2 \
+      libcairo2=1.18.4-1+b1 \
+      libmagic1t64=1:5.46-5 \
+      patch=2.8-2 \
   && apt purge -y --auto-remove \
   && rm -rf \
       /tmp/* \
@@ -30,9 +30,9 @@ RUN \
     set -x \
     && apt update \
     && apt install -y --no-install-recommends \
-        nginx-light=1.22.1-9+deb12u1 \
-        jq=1.6-2.1 \
-        xz-utils=5.4.1-0.2 \
+        nginx-light=1.26.3-3+deb13u2 \
+        jq=1.7.1-6+deb13u1 \
+        xz-utils=5.8.1-1 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \
@@ -40,9 +40,9 @@ RUN \
         /usr/src/*
 
 ARG \
-    BASHIO_VERSION=0.16.3 \
+    BASHIO_VERSION=0.17.5 \
     TEMPIO_VERSION=2024.11.2 \
-    S6_OVERLAY_VERSION=3.2.0.2
+    S6_OVERLAY_VERSION=3.2.2.0
 
 WORKDIR /usr/src
 


### PR DESCRIPTION
## Summary

- Bump Python from 3.12 to 3.13
- Bump Alpine from 3.20 to 3.22
- Bump Debian from Bookworm to Trixie
- Bump all system packages, s6-overlay, and bashio to latest versions

## Alpine Dockerfile

| Dependency | Old | New |
|---|---|---|
| Base image | `python:3.12-alpine3.20` | `python:3.13-alpine3.22` |
| bash | 5.2.26-r0 | 5.2.37-r0 |
| git | 2.45.3-r0 | 2.49.1-r0 |
| curl | 8.12.1-r0 | 8.14.1-r2 |
| openssh-client | `openssh-client`=9.7_p1-r5 | `openssh-client-default`=10.0_p1-r10 |
| cairo | 1.18.0-r0 | 1.18.4-r0 |
| libmagic | 5.45-r1 | 5.46-r2 |
| patch | 2.7.6-r10 | 2.8-r0 |
| nginx | 1.26.3-r0 | 1.28.3-r0 |
| jq | 1.7.1-r0 | 1.8.1-r0 |
| xz | 5.6.2-r1 | 5.8.1-r0 |
| s6-overlay | 3.2.0.2 | 3.2.2.0 |
| bashio | 0.16.3 | 0.17.5 |

## Debian Dockerfile

| Dependency | Old | New |
|---|---|---|
| Base image | `python:3.12-slim-bookworm` | `python:3.13-slim-trixie` |
| iputils-ping | 3:20221126-1+deb12u1 | 3:20240905-3 |
| git | 1:2.39.5-0+deb12u2 | 1:2.47.3-0+deb13u1 |
| curl | 7.88.1-10+deb12u12 | 8.14.1-2+deb13u2 |
| openssh-client | 1:9.2p1-2+deb12u5 | 1:10.0p1-7+deb13u2 |
| libcairo2 | 1.16.0-7 | 1.18.4-1+b1 |
| libmagic | `libmagic1`=1:5.44-3 | `libmagic1t64`=1:5.46-5 |
| patch | 2.7.6-7 | 2.8-2 |
| nginx-light | 1.22.1-9+deb12u1 | 1.26.3-3+deb13u2 |
| jq | 1.6-2.1 | 1.7.1-6+deb13u1 |
| xz-utils | 5.4.1-0.2 | 5.8.1-1 |
| s6-overlay | 3.2.0.2 | 3.2.2.0 |
| bashio | 0.16.3 | 0.17.5 |

### Notable package name changes

- **Alpine**: `openssh-client` renamed to `openssh-client-default` in Alpine 3.22
- **Debian**: `libmagic1` renamed to `libmagic1t64` in Trixie (64-bit time_t transition)