### PR TITLE
Remove nginx from ha-addon base image

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -32,7 +32,6 @@ RUN \
     set -x \
     && apt update \
     && apt install -y --no-install-recommends \
-        nginx-light=1.26.3-3+deb13u6 \
         jq=1.7.1-6+deb13u2 \
         xz-utils=5.8.1-1 \
     && rm -rf \


### PR DESCRIPTION
## Summary

nginx is no longer needed in the Home Assistant add-on base image, so this drops the `nginx-light` package from the `ha-addon` stage to slim the resulting image.