### PR TITLE
Replace Dependabot with self-hosted Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,54 @@
+name: Renovate
+
+on:
+  schedule:
+    # Weekly, Monday 04:00 UTC
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Renovate log level"
+        required: false
+        default: "info"
+        type: choice
+        options:
+          - info
+          - debug
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+          # Required so the github-actions manager can update workflow files.
+          permission-workflows: write
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Renovate
+        uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd  # v46.1.15
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # Commit via the GitHub API so commits are attributed to the app.
+          RENOVATE_PLATFORM_COMMIT: "enabled"
+          RENOVATE_ONBOARDING: "false"
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -40,10 +40,12 @@ RUN \
         /var/lib/apt/lists/* \
         /usr/src/*
 
-ARG \
-    BASHIO_VERSION=0.17.5 \
-    TEMPIO_VERSION=2024.11.2 \
-    S6_OVERLAY_VERSION=3.2.2.0
+# renovate: datasource=github-releases depName=hassio-addons/bashio
+ARG BASHIO_VERSION=0.17.5
+# renovate: datasource=github-releases depName=home-assistant/tempio versioning=loose
+ARG TEMPIO_VERSION=2024.11.2
+# renovate: datasource=github-releases depName=just-containers/s6-overlay versioning=loose
+ARG S6_OVERLAY_VERSION=3.2.2.0
 
 WORKDIR /usr/src
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Dockerfile$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+ARG \\w+=(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "{{{datasource}}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Dockerfile$/"],
+      "matchStrings": [
+        "\\s(?<depName>[a-z][a-z0-9.+-]*)=(?<currentValue>[0-9][^\\s\\\\]*)"
+      ],
+      "datasourceTemplate": "deb",
+      "versioningTemplate": "deb"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://security.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
+      "commitMessageTopic": "{{depName}} (apt)"
+    }
+  ]
+}


### PR DESCRIPTION
Replaces the Dependabot config with a self-hosted Renovate workflow that runs as the `esphome[bot]` GitHub App on a weekly schedule.

Dependabot only managed the GitHub Actions in this repo. Renovate covers everything versioned in the Dockerfile:

- **Base image** (`FROM python:...`) and **GitHub Actions** — built-in managers.
- **Bundled tool versions** (`BASHIO_VERSION`, `TEMPIO_VERSION`, `S6_OVERLAY_VERSION`) — a custom manager resolves these against the `github-releases` datasource using `# renovate:` annotations added next to each `ARG`.
- **Pinned apt package versions** — a custom manager resolves the `pkg=version` pins against the `deb` datasource (Debian Trixie main, plus the updates and security pockets).

The workflow mints a token via `actions/create-github-app-token` (org-standard pin) using the org `ESPHOME_GITHUB_APP_CLIENT_ID` var and the repo `ESPHOME_GITHUB_APP_PRIVATE_KEY` secret, with `contents`, `pull-requests`, `issues`, and `workflows` write scopes. `RENOVATE_PLATFORM_COMMIT` is enabled so commits are attributed to the app.

The `deb` datasource handling for the apt pins is the part to validate on the first run — trigger the workflow manually with `logLevel=debug` and check the lookups resolve across the trixie/updates/security suites.