### PR TITLE
Add esphome's build deps (build-essential, libusb-1.0-0, ccache) to base

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -13,6 +13,7 @@ RUN \
       libcairo2=1.18.4-1+b1 \
       libmagic1t64=1:5.46-5 \
       patch=2.8-2 \
+      ccache=4.11.2-2 \
   && apt purge -y --auto-remove \
   && rm -rf \
       /tmp/* \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -13,6 +13,8 @@ RUN \
       libcairo2=1.18.4-1+b1 \
       libmagic1t64=1:5.46-5 \
       patch=2.8-2 \
+      build-essential=12.12 \
+      libusb-1.0-0=2:1.0.28-1 \
       ccache=4.11.2-2 \
   && apt purge -y --auto-remove \
   && rm -rf \


### PR DESCRIPTION
Moves the apt packages esphome installs in its app Dockerfile into the shared base image, pinned to trixie versions to match the existing convention:

- **build-essential** (`12.12`) — compiles Python C extensions (e.g. `ruamel.yaml.clib`, pulled by ESP-IDF's idf-component-manager) during install.
- **libusb-1.0-0** (`2:1.0.28-1`) — runtime dep so `idf_tools.py` can validate `openocd-esp32`, which dynamically links `libusb-1.0.so.0` (without it the install aborts with exit 127).
- **ccache** (`4.11.2-2`) — speeds up repeat ESP-IDF compiles (`IDF_CCACHE_ENABLE`); ESP-IDF silently skips it when the binary isn't on `PATH`.

This lets esphome's app Dockerfile drop its `RUN apt-get …` step entirely once it bumps `BUILD_BASE_VERSION` to a release containing this. Follows up review feedback on esphome/esphome#17157 (ccache landed in the app image; this moves it — and the rest — to the base where it belongs).