### PR TITLE
Add runtime image targets without build toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,24 @@ jobs:
           fi
           echo version="$version" >> $GITHUB_OUTPUT
 
+      - name: Build runtime image
+        id: build-runtime
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: ${{ matrix.base }}
+          file: ./${{ matrix.base }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          target: runtime
+          cache-from: type=registry,ref=${{ steps.image.outputs.image }}:cache-${{ matrix.base }}
+          cache-to: ${{ github.event_name == 'release' && format('type=registry,ref={0}:cache-{1},mode=max', steps.image.outputs.image, matrix.base) || '' }}
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image }}:${{ matrix.base }}-runtime-${{ steps.get_tag.outputs.version }}
+
       - name: Build base image
         id: build-base
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
@@ -84,6 +102,24 @@ jobs:
           push: true
           tags: |
             ${{ steps.image.outputs.image }}:${{ matrix.base }}-${{ steps.get_tag.outputs.version }}
+
+      - name: Build ha-addon-runtime image
+        id: build-ha-addon-runtime
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: ${{ matrix.base }}
+          file: ./${{ matrix.base }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          target: ha-addon-runtime
+          cache-from: type=registry,ref=${{ steps.image.outputs.image }}:cache-${{ matrix.base }}
+          cache-to: ${{ github.event_name == 'release' && format('type=registry,ref={0}:cache-{1},mode=max', steps.image.outputs.image, matrix.base) || '' }}
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image }}:${{ matrix.base }}-ha-addon-runtime-${{ steps.get_tag.outputs.version }}
 
       - name: Build ha-addon image
         id: build-ha-addon
@@ -114,12 +150,30 @@ jobs:
             -f ./${{ matrix.base }}/Dockerfile \
             ./${{ matrix.base }}
 
+      - name: Build runtime image (local)
+        if: github.event_name == 'pull_request' && matrix.base == 'debian'
+        run: |
+          docker build \
+            --target runtime \
+            -t "ghcr.io/esphome/docker-base:${{ matrix.base }}-runtime-pr-${{ github.event.pull_request.number }}" \
+            -f ./${{ matrix.base }}/Dockerfile \
+            ./${{ matrix.base }}
+
       - name: Build ha-addon image (local)
         if: github.event_name == 'pull_request' && matrix.base == 'debian'
         run: |
           docker build \
             --target ha-addon \
             -t "ghcr.io/esphome/docker-base:${{ matrix.base }}-ha-addon-pr-${{ github.event.pull_request.number }}" \
+            -f ./${{ matrix.base }}/Dockerfile \
+            ./${{ matrix.base }}
+
+      - name: Build ha-addon-runtime image (local)
+        if: github.event_name == 'pull_request' && matrix.base == 'debian'
+        run: |
+          docker build \
+            --target ha-addon-runtime \
+            -t "ghcr.io/esphome/docker-base:${{ matrix.base }}-ha-addon-runtime-pr-${{ github.event.pull_request.number }}" \
             -f ./${{ matrix.base }}/Dockerfile \
             ./${{ matrix.base }}
 
@@ -138,7 +192,6 @@ jobs:
             --target final \
             --build-arg BUILD_TYPE=docker \
             --build-arg BUILD_VERSION=ci \
-            --build-arg "BUILD_OS=${{ matrix.base }}" \
             --build-arg "BUILD_BASE_VERSION=pr-${{ github.event.pull_request.number }}" \
             -t esphome-test:latest \
             -f ./esphome/docker/Dockerfile \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:3.14-slim-trixie AS base
+FROM python:3.14-slim-trixie AS runtime
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Runtime-only packages (no compiler toolchain)
 RUN \
   set -x \
   && apt update \
@@ -13,9 +14,7 @@ RUN \
       libcairo2=1.18.4-1+b1 \
       libmagic1t64=1:5.46-5 \
       patch=2.8-2 \
-      build-essential=12.12 \
       libusb-1.0-0=2:1.0.28-1 \
-      ccache=4.11.2-2 \
   && apt purge -y --auto-remove \
   && rm -rf \
       /tmp/* \
@@ -29,7 +28,24 @@ ENV UV_SYSTEM_PYTHON=true
 ENV PIP_ROOT_USER_ACTION=ignore
 
 
-FROM base AS ha-addon
+# Builder stage: runtime + build-essential for compiling native Python extensions
+FROM runtime AS base
+
+RUN \
+  set -x \
+  && apt update \
+  && apt install -y --no-install-recommends \
+      build-essential=12.12 \
+      ccache=4.11.2-2 \
+  && apt purge -y --auto-remove \
+  && rm -rf \
+      /tmp/* \
+      /var/{cache,log}/* \
+      /var/lib/apt/lists/* \
+      /usr/src/*
+
+
+FROM runtime AS ha-addon-runtime
 
 RUN \
     set -x \
@@ -90,3 +106,20 @@ RUN \
 
 WORKDIR /root
 ENTRYPOINT ["/init"]
+
+
+# ha-addon with build tools (for pip install of native extensions)
+FROM ha-addon-runtime AS ha-addon
+
+RUN \
+  set -x \
+  && apt update \
+  && apt install -y --no-install-recommends \
+      build-essential=12.12 \
+      ccache=4.11.2-2 \
+  && apt purge -y --auto-remove \
+  && rm -rf \
+      /tmp/* \
+      /var/{cache,log}/* \
+      /var/lib/apt/lists/* \
+      /usr/src/*


### PR DESCRIPTION
I wanted to see if the ESPHome Docker image could be made lighter on my Home Assistant setup — it's currently ~940 MB which felt like a lot for a microcontroller configuration tool.

After investigating with `dive` and poking around the image layers, it turns out `build-essential` + GCC + sanitizer libraries account for ~250 MB but aren't needed at runtime — PlatformIO downloads its own cross-compilers (xtensa, arm-none-eabi) when it compiles firmware.

This PR splits the Dockerfile into:
- **`runtime`** — everything needed at runtime (git, curl, libusb, libcairo…) but no compiler toolchain
- **`base`** — runtime + build-essential (unchanged, used during `pip install` for native extensions)
- **`ha-addon-runtime`** / **`ha-addon`** — same split for the HA add-on variant

The `base` and `ha-addon` targets are fully backwards-compatible. The new `runtime` and `ha-addon-runtime` targets are meant to be used as the final stage in a multi-stage ESPHome build (companion PR: esphome/esphome#XXXX).

### Testing
- Built locally on amd64
- ESP32-S3 (ESP-IDF) firmware compiles successfully in the slim image
- Dashboard starts and serves correctly

### Note
I was assisted by Claude (Anthropic) in investigating the image size and drafting this change. Happy to iterate on feedback!
